### PR TITLE
refactor of client and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Source: [www.deepl.com](https://www.deepl.com/publisher.html)
 
 ### This project
 
-deeplgobindings allows automated interaction with DeepL translation's API in Golang. Please note that you only 
-have access to the API if you are a paid user with the plan "DeepL API".
+deeplgobindings allows automated interaction with DeepL translation's API in Golang.
 
 ## Features
 
 The following list contains all features which are/should be supported (in the future):
 - [x] translate Function (*/v2/translate*)
 - [x] usage Function (*/v2/usage*)
-- [x] support POST and GET request methods
+- [x] document translate Function (*/v2/document*)
+- [x] support POST and GET request methods (including file upload with multipart)
 - [ ] implement DeepL API's limitation rules
 
 ## Usage
@@ -32,5 +32,4 @@ If you are interested in some examples, see the examples directory in this repos
 
 ## Contribution
 
-Feel free to contribute and help this project to grow. You can also just suggest features/enhancements. In the future, 
-there will be a contributing file for newbies to read.
+Feel free to contribute and help this project to grow. You can also just suggest features/enhancements.

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	// unofficial internal HTTP status code for "Quota exceeded"
+	// StatusQuotaExceeded is the unofficial internal HTTP status code for "Quota exceeded"
 	StatusQuotaExceeded  = 456
 	translateFunctionUri = "translate"
 	usageFunctionUri     = "usage"
@@ -128,7 +128,7 @@ func (client *Client) doApiFunction(uri, method string, values *url.Values) (res
 	return
 }
 
-// ApiLang is a wrapper type for languages used in requests/responses within the translate function.
+// ApiLang is a wrapper type for languages used in requests/responses within the translation function.
 type ApiLang string
 
 const (
@@ -308,7 +308,7 @@ type TranslationRequest struct {
 	Formality ApiFormality
 }
 
-// TranslationResponse represents the data of the json response of the translate API function.
+// TranslationResponse represents the data of the json response of the translation API function.
 type TranslationResponse struct {
 	// Translations contains all requested translations and their results.
 	Translations []struct {

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -14,9 +14,8 @@ import (
 
 const (
 	// StatusQuotaExceeded is the unofficial internal HTTP status code for "Quota exceeded"
-	StatusQuotaExceeded  = 456
-	translateFunctionUri = "translate"
-	usageFunctionUri     = "usage"
+	StatusQuotaExceeded = 456
+	usageFunctionUri    = "usage"
 	// maximum body size - see https://www.deepl.com/docs-api/accessing-the-api/limits/
 	maxBodySize = 128 * 1024
 )
@@ -266,104 +265,6 @@ const (
 	// FormalityLess sets a more informal language.
 	FormalityLess = ApiFormality("more")
 )
-
-// TranslationRequest contains the payload data for each translation request.
-type TranslationRequest struct {
-	// field comments partially taken from official DeepL API documentation
-
-	// Text to be translated. Only UTF8-encoded plain text is supported. The parameter may be specified multiple times
-	// and translations are returned in the same order as in the input. Each of the parameter values may contain
-	// multiple sentences.
-	Text string
-	// SourceLang is the language of the text to be translated. If parameter is omitted, the API will detect the
-	// language of the text and translate it.
-	SourceLang ApiLang
-	// TargetLang determines the language into which you want to translate.
-	TargetLang ApiLang
-	// TagHandling sets which kind of tags should be handled. Comma-separated list of one or more values. See official
-	// DeepL API documentation for more details about tag handling.
-	TagHandling []string
-	// NonSplittingTags contains a list of XML tags which never split sentences. See official DeepL API documentation
-	// for more details about tag handling.
-	NonSplittingTags []string
-	// IgnoreTags contains a list of XML tags whose content is never translated. See official DeepL API documentation
-	// for more details about tag handling.
-	IgnoreTags []string
-	// DoNotSplitSentences sets whether the translation engine should first split the input into sentences. False by
-	// default.
-	//
-	// For applications which are sending one sentence per text parameter, it is advisable to set this to false, in
-	// order to prevent the engine from splitting the sentence unintentionally.
-	DoNotSplitSentences bool
-	// Sets whether the translation engine should preserve some aspects of the formatting, even if it would usually
-	// correct some aspects. False by default.
-	//
-	// The formatting aspects controlled by the setting include:
-	// 	punctuation at the beginning and end of the sentence,
-	// 	upper/lower case at the beginning of the sentence.
-	PreserveFormatting bool
-	// Formality Sets whether the translated text should lean towards formal or informal language. This feature
-	// currently only works for target languages DE (German), FR (French), IT (Italian), ES (Spanish), NL (Dutch),
-	// PL (Polish), PT-PT, PT-BR (Portuguese) and RU (Russian).
-	Formality ApiFormality
-}
-
-// TranslationResponse represents the data of the json response of the translation API function.
-type TranslationResponse struct {
-	// Translations contains all requested translations and their results.
-	Translations []struct {
-		// DetectedSourceLanguage contains the ApiLang detected by the DeepL API.
-		DetectedSourceLanguage ApiLang `json:"detected_source_language"`
-		// Text contains the translated text.
-		Text string `json:"text"`
-	} `json:"translations"`
-}
-
-// Translate translates the requested text and returns the translated text or an error if something went wrong.
-func (client *Client) Translate(req *TranslationRequest) (resp *TranslationResponse, err error) {
-	// parse url values for HTTP request
-	values := &url.Values{}
-	if len(req.Text) == 0 {
-		return resp, errors.New("'Text' field of translation request cannot be empty")
-	}
-	values.Add("text", req.Text)
-	if req.SourceLang != "" {
-		values.Add("source_lang", req.SourceLang.String())
-	}
-	if len(req.TargetLang) == 0 {
-		return resp, errors.New("'TargetLang' field of translation request cannot be omitted")
-	}
-	values.Add("target_lang", req.TargetLang.String())
-	if len(req.TagHandling) > 0 {
-		values.Add("tag_handling", strings.Join(req.TagHandling, ","))
-	}
-	if len(req.NonSplittingTags) > 0 {
-		values.Add("non_splitting_tags", strings.Join(req.NonSplittingTags, ","))
-	}
-	if len(req.IgnoreTags) > 0 {
-		values.Add("ignore_tags", strings.Join(req.IgnoreTags, ","))
-	}
-	// inverted functionality from DeepL in order to be able to use the default values of Go
-	if req.DoNotSplitSentences {
-		values.Add("split_sentences", "0")
-	}
-	// do not get confused with the different handling for both booleans
-	if req.PreserveFormatting {
-		values.Add("preserve_formatting", "1")
-	}
-	if len(req.Formality) > 0 {
-		values.Add("formality", string(req.Formality))
-	}
-	var httpResp *http.Response
-	httpResp, err = client.doApiFunction(translateFunctionUri, http.MethodPost, values)
-	if err != nil {
-		return
-	}
-	defer httpResp.Body.Close()
-	resp = &TranslationResponse{}
-	err = json.NewDecoder(httpResp.Body).Decode(resp)
-	return
-}
 
 // UsageResponse represents the data of the json response of the usage API function.
 type UsageResponse struct {

--- a/pkg/document.go
+++ b/pkg/document.go
@@ -49,7 +49,7 @@ type DocumentTranslationStartResponse struct {
 // DocumentTranslationStatusRequest and DocumentTranslationStartResponse share the same fields
 type DocumentTranslationStatusRequest DocumentTranslationStartResponse
 
-// DocumentTranslationStatus is a wrapper type for various states that can occurr during translation
+// DocumentTranslationStatus is a wrapper type for various states that can occur during translation
 type DocumentTranslationStatus string
 
 const (
@@ -74,7 +74,7 @@ type DocumentTranslationStatusResponse struct {
 	// BilledCharacters is the amount of characters billed
 	BilledCharacters uint
 
-	// ErrorMessage describes an error during translation, if one occurred (if not the values is nil)
+	// ErrorMessage describes an error during translation, if one occurred (if not the value is nil)
 	ErrorMessage *string
 }
 

--- a/pkg/errors.go
+++ b/pkg/errors.go
@@ -62,7 +62,7 @@ func (err *TooManyRequestsErr) Error() string {
 	return fmt.Sprintf("server returned status code 429 (too many request): %s", strconv.Quote(err.Message))
 }
 
-// AuthFailedErr indicates the response code 403 returned by the remote API server and contains the error message.
+// QuotaExceededErr indicates the response code 403 returned by the remote API server and contains the error message.
 // Normally this error occurs if the character limit has been reached.
 type QuotaExceededErr struct {
 	*KnownRequestErrData

--- a/pkg/text.go
+++ b/pkg/text.go
@@ -1,0 +1,111 @@
+package deeplclient
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	translateFunctionUri = "translate"
+)
+
+// TranslationRequest contains the payload data for each translation request.
+type TranslationRequest struct {
+	// field comments partially taken from official DeepL API documentation
+
+	// Text to be translated. Only UTF8-encoded plain text is supported. The parameter may be specified multiple times
+	// and translations are returned in the same order as in the input. Each of the parameter values may contain
+	// multiple sentences.
+	Text string
+	// SourceLang is the language of the text to be translated. If parameter is omitted, the API will detect the
+	// language of the text and translate it.
+	SourceLang ApiLang
+	// TargetLang determines the language into which you want to translate.
+	TargetLang ApiLang
+	// TagHandling sets which kind of tags should be handled. Comma-separated list of one or more values. See official
+	// DeepL API documentation for more details about tag handling.
+	TagHandling []string
+	// NonSplittingTags contains a list of XML tags which never split sentences. See official DeepL API documentation
+	// for more details about tag handling.
+	NonSplittingTags []string
+	// IgnoreTags contains a list of XML tags whose content is never translated. See official DeepL API documentation
+	// for more details about tag handling.
+	IgnoreTags []string
+	// DoNotSplitSentences sets whether the translation engine should first split the input into sentences. False by
+	// default.
+	//
+	// For applications which are sending one sentence per text parameter, it is advisable to set this to false, in
+	// order to prevent the engine from splitting the sentence unintentionally.
+	DoNotSplitSentences bool
+	// Sets whether the translation engine should preserve some aspects of the formatting, even if it would usually
+	// correct some aspects. False by default.
+	//
+	// The formatting aspects controlled by the setting include:
+	// 	punctuation at the beginning and end of the sentence,
+	// 	upper/lower case at the beginning of the sentence.
+	PreserveFormatting bool
+	// Formality Sets whether the translated text should lean towards formal or informal language. This feature
+	// currently only works for target languages DE (German), FR (French), IT (Italian), ES (Spanish), NL (Dutch),
+	// PL (Polish), PT-PT, PT-BR (Portuguese) and RU (Russian).
+	Formality ApiFormality
+}
+
+// TranslationResponse represents the data of the json response of the translation API function.
+type TranslationResponse struct {
+	// Translations contains all requested translations and their results.
+	Translations []struct {
+		// DetectedSourceLanguage contains the ApiLang detected by the DeepL API.
+		DetectedSourceLanguage ApiLang `json:"detected_source_language"`
+		// Text contains the translated text.
+		Text string `json:"text"`
+	} `json:"translations"`
+}
+
+// Translate translates the requested text and returns the translated text or an error if something went wrong.
+func (client *Client) Translate(req *TranslationRequest) (resp *TranslationResponse, err error) {
+	// parse url values for HTTP request
+	values := &url.Values{}
+	if len(req.Text) == 0 {
+		return resp, errors.New("'Text' field of translation request cannot be empty")
+	}
+	values.Add("text", req.Text)
+	if req.SourceLang != "" {
+		values.Add("source_lang", req.SourceLang.String())
+	}
+	if len(req.TargetLang) == 0 {
+		return resp, errors.New("'TargetLang' field of translation request cannot be omitted")
+	}
+	values.Add("target_lang", req.TargetLang.String())
+	if len(req.TagHandling) > 0 {
+		values.Add("tag_handling", strings.Join(req.TagHandling, ","))
+	}
+	if len(req.NonSplittingTags) > 0 {
+		values.Add("non_splitting_tags", strings.Join(req.NonSplittingTags, ","))
+	}
+	if len(req.IgnoreTags) > 0 {
+		values.Add("ignore_tags", strings.Join(req.IgnoreTags, ","))
+	}
+	// inverted functionality from DeepL in order to be able to use the default values of Go
+	if req.DoNotSplitSentences {
+		values.Add("split_sentences", "0")
+	}
+	// do not get confused with the different handling for both booleans
+	if req.PreserveFormatting {
+		values.Add("preserve_formatting", "1")
+	}
+	if len(req.Formality) > 0 {
+		values.Add("formality", string(req.Formality))
+	}
+	var httpResp *http.Response
+	httpResp, err = client.doApiFunction(translateFunctionUri, http.MethodPost, values)
+	if err != nil {
+		return
+	}
+	defer httpResp.Body.Close()
+	resp = &TranslationResponse{}
+	err = json.NewDecoder(httpResp.Body).Decode(resp)
+	return
+}

--- a/pkg/text_test.go
+++ b/pkg/text_test.go
@@ -6,9 +6,8 @@ import (
 	"testing"
 )
 
-const endpointUrl = "https://api-free.deepl.com/v2/"
-
-func TestGetUsage(t *testing.T) {
+// TestTranslation tests the functionality of the Translate API function within the deeplclient.
+func TestTranslation(t *testing.T) {
 	authKey := os.Getenv("DEEPL_TEST_AUTH_KEY")
 	if authKey == "" {
 		t.Fatal("could not find 'DEEPL_TEST_AUTH_KEY' environment variable")
@@ -18,14 +17,14 @@ func TestGetUsage(t *testing.T) {
 		AuthKey:     []byte(authKey),
 		EndpointUrl: endpointUrl,
 	}
-	if resp, err := client.GetUsage(); err != nil {
+	if resp, err := client.Translate(&TranslationRequest{
+		Text:       "Hallo Welt!",
+		TargetLang: LangEN,
+	}); err != nil {
 		t.Fatal(err)
 	} else {
-		t.Logf("received usage response from DeepL API: %+v", resp)
-		if resp.CharacterCount < 0 {
-			t.Fail()
-		}
-		if resp.CharacterLimit < 0 {
+		t.Logf("received translation response from DeepL API: %+v", resp)
+		if len(resp.Translations) != 1 {
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
Due to the rising functionality and age of this project, some refactoring thoughts occurred so I decided to change the strcuture of the project a bit.

- client.go (and client_test.go) now contains only the basic API wrapper functions to communicate to the HTTPS API
- text.go (and text_test.go) is a new file and contains the functionality for the (text) translation API
- document.go (no test available yet, feel free to contribute, reading person ;) ) still contains the functionality for the document translation API

In the same process, I decided to fix some typos in the documentation and update the README to keep track of the development process over the last years