### PR TITLE
fix: named parameters return muted

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -56,11 +56,14 @@ func handleApiError(resp *http.Response) (returnResponse bool, err error) {
 		err = UnwrappedApiResponseCodeErr(resp.StatusCode)
 		return false, err
 	}
-	if jsonErr := json.NewDecoder(resp.Body).Decode(err); jsonErr != nil {
+	if err != nil {
 		return false, err
 	}
+	if jsonErr := json.NewDecoder(resp.Body).Decode(err); jsonErr != nil {
+		err = jsonErr
+	}
 
-	return
+	return false, err
 }
 
 // doApiFunctionWithMultipartForm is an internally used function to execute API functions which require upload

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -60,7 +60,7 @@ func handleApiError(resp *http.Response) (returnResponse bool, err error) {
 		return false, err
 	}
 
-	return true, nil
+	return
 }
 
 // doApiFunctionWithMultipartForm is an internally used function to execute API functions which require upload


### PR DESCRIPTION
If we got an error, and it got assigned to a named return var, we should not overwrite it at the end.

![image](https://user-images.githubusercontent.com/239034/211166785-f47acc5a-50fa-4cb0-ad08-0eef80caa41d.png)
